### PR TITLE
Fix missing credentials with subprojects

### DIFF
--- a/src/main/java/awsm/AwsmCredentialsPlugin.java
+++ b/src/main/java/awsm/AwsmCredentialsPlugin.java
@@ -46,6 +46,7 @@ public class AwsmCredentialsPlugin implements Plugin<Project>
 
     public void applyForProject(Project project)
     {
+        project.getRepositories().all(this::repositoryAdded);
         project.afterEvaluate(p -> {
             project.getRepositories().all(this::repositoryAdded);
             final PublishingExtension publishingExtension = project.getExtensions().findByType(PublishingExtension.class);


### PR DESCRIPTION
awsm-credentials-plugin fails to setConfiguredCredentials with my project that has subprojects.
```
* What went wrong:
A problem occurred evaluating root project 'my-project-name'.
> Could not resolve all dependencies for configuration ':common:detachedConfiguration1'.
   > S3 resource should either specify AwsIamAutentication or provide some AwsCredentials.
```

This is caused since setConfiguredCredentials() is not executed because gradle seems to use an s3 url before afterEvaluate() event.

Changes in this pull request tries update credentials before the afterEvaluate event.